### PR TITLE
Initialize time:writers with 0

### DIFF
--- a/tcl/munin.tcl
+++ b/tcl/munin.tcl
@@ -276,7 +276,7 @@ switch [ns_queryget t ""] {
     }
 
     "threadcpu" {
-	array set tt {logwriter 0 sum 0}
+	array set tt {writers 0 logwriter 0 sum 0}
         if {[info command ::xo::system_stats] ne ""} {
 	   ::xo::system_stats aggcpuinfo ut st tt
         } else {


### PR DESCRIPTION
This prevents warnings in the log file (if time:writers is configured in the plugin, but no value is returned).
Moreover, the current "sum" CDEF fails if there are NaN values in the addition (this could be fixed in the CDEF as well, but the is not very readable).